### PR TITLE
Exposed provisioning API methods to view exchanges and available addresses

### DIFF
--- a/lib/tropo-provisioning.js
+++ b/lib/tropo-provisioning.js
@@ -55,8 +55,13 @@ TropoProvision.prototype.viewAddresses = function(applicationID) {
 	return this.makeApiCall('GET', provisioningUrlHost, path, null);
 };
 
-vviewExchanges = function() {
+TropoProvision.prototype.viewExchanges = function() {
 	var path = provisioningUrlPath + 'exchanges';
+	return this.makeApiCall('GET', provisioningUrlHost, path, null);
+};
+
+TropoProvision.prototype.viewAvailableAddresses = function(prefix) {
+	var path = '/addresses?available&prefix='+prefix;
 	return this.makeApiCall('GET', provisioningUrlHost, path, null);
 };
 


### PR DESCRIPTION
Exports the view exchanges method that was previously not exported and adds a similar method to search for numbers by prefix as per the following documents:

https://www.tropo.com/docs/rest/prov_view_exchanges.htm
https://www.tropo.com/docs/rest/prov_viewing_number_prefix.htm
