### PR TITLE
Fixing typo in viewAddresses URL, adding ability to view application addresses by type or number

### DIFF
--- a/lib/tropo-provisioning.js
+++ b/lib/tropo-provisioning.js
@@ -50,8 +50,13 @@ TropoProvision.prototype.viewSpecificApplication = function(applicationID) {
 	return this.makeApiCall('GET', provisioningUrlHost, path, null);	
 };
 
-TropoProvision.prototype.viewAddresses = function(applicationID) {
+TropoProvision.prototype.viewAddresses = function(applicationID, type, address) {
 	var path = provisioningUrlPath + 'applications/' + applicationID + '/addresses';
+	var validTypes = ['number', 'sip', 'aim', 'skype'];
+	if ((type != null) && validTypes.indexOf(type) >= 0) {
+		path += '/' + type;
+		if(address != null) path += '/' + address;
+	}
 	return this.makeApiCall('GET', provisioningUrlHost, path, null);
 };
 


### PR DESCRIPTION
TropoProvisioning.viewAddresses accidentally had the URL .../addreses instead of .../addresses
Also added optional type and address arguments to viewAddresses so that it is possible to query specific types of addresses or to query a single address.
