### PR TITLE
say in a message is its own dictionary

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -72,7 +72,7 @@ MachineDetection = function(introduction, voice){
 };
 
 Message = function(say, to, answerOnMedia, channel, from, name, network, required, timeout, voice) {
-    this.say = say;
+    this.say = new Say(say);
     this.to = to;
     this.answerOnMedia = answerOnMedia;
     this.channel = channel;
@@ -139,7 +139,7 @@ Result = function(json) {
     this.userType = result.result.userType;
     this.calledID = result.result.calledID;
     this.connectedDuration = result.result.connectedDuration;
-    this.actions = result.result.actions;		
+    this.actions = result.result.actions;
     this.name = result.result.actions.name;
     this.attempts = result.result.actions.attempts;
     this.disposition = result.result.actions.disposition;
@@ -149,7 +149,7 @@ Result = function(json) {
     this.value = result.result.actions.value;
     this.concept = result.result.actions.concept;
     this.xml = result.result.actions.xml;
-    
+
 
     return this;
 };
@@ -218,7 +218,7 @@ Transfer = function(to, answerOnMedia, choices, from, headers, name, on, require
             this.on += comma + on[i];
             comma = ",";
         }
-        
+
     }else{
         this.on = (typeof(on) == 'Object') ? serializeProperty(on) : on;
     }


### PR DESCRIPTION
The message API expects that the say api is its own dictionary, not simply a key value pair. (See example at the bottom of this page: https://www.tropo.com/docs/webapi/message)